### PR TITLE
Fixes failing test due to denylist reserved address and removes unecesary imports

### DIFF
--- a/tests/Move.toml
+++ b/tests/Move.toml
@@ -10,8 +10,8 @@ controlled_treasury = { local = "../treasury" }
 tests = "0x0"
 
 # addresses used in testing
-admin = "0xA"      # admin
-wl_admin = "0xB"   # whitelist admin
-dl_admin = "0xC"   # denylist admin
-user = "0xD"       # user
-mint_admin = "0xE" # mint admin
+admin = "0xAA"      # admin
+wl_admin = "0xBB"   # whitelist admin
+dl_admin = "0xCC"   # denylist admin
+user = "0xDD"       # user
+mint_admin = "0xEE" # mint admin

--- a/tests/sources/otw.move
+++ b/tests/sources/otw.move
@@ -3,8 +3,6 @@
 
 #[test_only]
 module tests::otw {
-    use std::option;
-    use sui::tx_context::TxContext;
     use sui::coin::{Self, DenyCap, TreasuryCap};
     use sui::test_utils;
 

--- a/tests/sources/tests.move
+++ b/tests/sources/tests.move
@@ -4,7 +4,6 @@
 #[test_only]
 #[allow(unused_function)]
 module tests::treasury_tests {
-    use sui::tx_context::{Self, TxContext};
     use sui::test_utils;
     use sui::deny_list;
     use sui::coin;


### PR DESCRIPTION
The test `test_denylist_add_remove` was failing due to the fact that the address 0xD (test users address) is a reserved address for [Denylist](https://github.com/MystenLabs/sui/blob/7e33c3f4d4fb59ead85118b2b04ef95ec08f1bae/crates/sui-framework/packages/sui-framework/sources/deny_list.move#L39).