### PR TITLE
Use a combination of witness and cap to make adding/removing capabilities composable

### DIFF
--- a/treasury/sources/burn.move
+++ b/treasury/sources/burn.move
@@ -1,0 +1,34 @@
+module controlled_treasury::burn {
+
+    use controlled_treasury::treasury::{ControlledTreasury, AdminCap};
+
+    use sui::coin::Coin;
+
+    /// BurnCap is a capability for burning coins.
+    public struct BurnCap has key {
+        id: UID
+    }
+
+    /// Witness for enabling BurnCap to burn coins.
+    public struct BurnAuth has store, drop {}
+
+    /// Owner of `treasury::AdminCap` can add new burners.
+    public fun add_burn_auth<T>(admin_cap: &AdminCap<T>, treasury: &mut ControlledTreasury<T>, ctx: &mut TxContext): BurnCap {
+        let mint_cap = BurnCap { id: object::new(ctx) };
+        admin_cap.add_authorization(treasury, &mint_cap, BurnAuth {});
+        mint_cap
+    }
+
+    /// Owner of `BurnCap` can burn coins.
+    public fun burn<T>(mint_cap: &BurnCap, treasury: &mut ControlledTreasury<T>, coin: Coin<T>) {
+        treasury.borrow_treasury_cap_mut(mint_cap, BurnAuth {}).burn(coin);
+    }
+
+    // ============================= Demo functions =============================
+    // The below functions can be called via ptb directly
+
+    /// Admin can remove a `BurnAuth` for a `BurnCap`.
+    public fun remove_burn_auth<T>(admin_cap: &AdminCap<T>, treasury: &mut ControlledTreasury<T>, burn_cap_id: ID) {
+        admin_cap.remove_authorization<T, BurnAuth>(treasury, burn_cap_id);
+    }
+}

--- a/treasury/sources/deny_add.move
+++ b/treasury/sources/deny_add.move
@@ -1,0 +1,50 @@
+module controlled_treasury::deny_add {
+
+    use controlled_treasury::treasury::{AdminCap, ControlledTreasury};
+
+    use sui::coin;
+    use sui::deny_list::DenyList;
+
+    /// DenyAddCap is a capability for adding addresses to DenyList.
+    public struct DenyAddCap has key {
+        id: UID
+    }
+
+    /// Witness for enabling DenyAddCap to edit DenyList.
+    public struct DenyAddAuth has store, drop {}
+
+    /// Owner of `treasury::AdminCap` can create new `DenyAddCap`s.
+    public fun add_deny_add_auth<T>(
+        admin_cap: &AdminCap<T>,
+        treasury: &mut ControlledTreasury<T>,
+        ctx: &mut TxContext
+    ): DenyAddCap {
+        let deny_add_cap = DenyAddCap { id: object::new(ctx) };
+        admin_cap.add_authorization(treasury, &deny_add_cap, DenyAddAuth {});
+        deny_add_cap
+    }
+
+    /// Owner of `DenyAddCap` can add an address to `DenyList`.
+    public fun add_deny_address<T>(
+        deny_add_cap: &DenyAddCap,
+        deny_list: &mut DenyList,
+        treasury: &mut ControlledTreasury<T>,
+        addr: address,
+        ctx: &mut TxContext
+    ) {
+        coin::deny_list_add<T>(
+            deny_list,
+            treasury.borrow_deny_cap_mut(deny_add_cap, DenyAddAuth {}),
+            addr,
+            ctx
+        );
+    }
+
+    // ============================= Demo functions =============================
+    // The below functions can be called via ptb directly
+
+    /// Admin can remove `DenyAddAuth`, to disable a `DenyAddCap`.
+    public fun remove_deny_add_auth<T>(admin_cap: &AdminCap<T>, treasury: &mut ControlledTreasury<T>, deny_cap_add_id: ID) {
+        admin_cap.remove_authorization<T, DenyAddAuth>(treasury, deny_cap_add_id);
+    }
+}

--- a/treasury/sources/deny_revoke.move
+++ b/treasury/sources/deny_revoke.move
@@ -1,0 +1,50 @@
+module controlled_treasury::deny_revoke {
+
+    use controlled_treasury::treasury::{AdminCap, ControlledTreasury};
+
+    use sui::coin;
+    use sui::deny_list::DenyList;
+
+    /// DenyRevokeCap is a capability for revoking denylist addresses, thus reenable them to transfer coins.
+    public struct DenyRevokeCap has key {
+        id: UID
+    }
+
+    /// Witness for enabling DenyRevokeCap to remove from DenyList.
+    public struct DenyRevokeAuth has store, drop {}
+
+    /// Owner of `treasury::AdminCap` can create new `DenyRevokeCap`s.
+    public fun add_deny_revoke_auth<T>(
+        admin_cap: &AdminCap<T>,
+        treasury: &mut ControlledTreasury<T>,
+        ctx: &mut TxContext
+    ): DenyRevokeCap {
+        let deny_add_cap = DenyRevokeCap { id: object::new(ctx) };
+        admin_cap.add_authorization(treasury, &deny_add_cap, DenyRevokeAuth {});
+        deny_add_cap
+    }
+
+    /// Owner of `DenyRevokeCap` can remove addresses from the denylist.
+    public fun revoke_deny_address<T>(
+        deny_add_cap: &DenyRevokeCap,
+        deny_list: &mut DenyList,
+        treasury: &mut ControlledTreasury<T>,
+        addr: address,
+        ctx: &mut TxContext
+    ) {
+        coin::deny_list_remove<T>(
+            deny_list,
+            treasury.borrow_deny_cap_mut(deny_add_cap, DenyRevokeAuth {}),
+            addr,
+            ctx
+        );
+    }
+
+    // ============================= Demo functions =============================
+    // The below functions can be called via ptb directly
+
+    /// Admin can remove `DenyRevokeAuth` to disable a `DenyRevokeCap`.
+    public fun remove_deny_revoke_auth<T>(admin_cap: &AdminCap<T>, treasury: &mut ControlledTreasury<T>, deny_revoke_cap_id: ID) {
+        admin_cap.remove_authorization<T, DenyRevokeAuth>(treasury, deny_revoke_cap_id);
+    }
+}

--- a/treasury/sources/mint.move
+++ b/treasury/sources/mint.move
@@ -1,0 +1,34 @@
+module controlled_treasury::mint {
+
+    use controlled_treasury::treasury::{ControlledTreasury, AdminCap};
+
+    use sui::coin::Coin;
+
+    /// MintCap is a capability for minting coins.
+    public struct MintCap has key {
+        id: UID
+    }
+
+    /// Witness for enabling MintCap to mint coins.
+    public struct MintAuth has store, drop {}
+
+    /// Owner of `treasury::AdminCap` can add new minters.
+    public fun add_mint_auth<T>(admin_cap: &AdminCap<T>, treasury: &mut ControlledTreasury<T>, ctx: &mut TxContext): MintCap {
+        let mint_cap = MintCap { id: object::new(ctx) };
+        admin_cap.add_authorization(treasury, &mint_cap, MintAuth {});
+        mint_cap
+    }
+
+    /// Owner of `MintCap` can mint coins.
+    public fun mint<T>(mint_cap: &MintCap, treasury: &mut ControlledTreasury<T>, amount: u64, ctx: &mut TxContext): Coin<T> {
+        treasury.borrow_treasury_cap_mut(mint_cap, MintAuth {}).mint(amount, ctx)
+    }
+
+    // ============================= Demo functions =============================
+    // The below functions can be called via ptb directly
+
+    /// Admin can remove `MintAuth` for a `MintCap`.
+    public fun remove_mint_auth<T>(admin_cap: &AdminCap<T>, treasury: &mut ControlledTreasury<T>, mint_cap_id: ID) {
+        admin_cap.remove_authorization<T, MintAuth>(treasury, mint_cap_id);
+    }
+}

--- a/treasury/sources/treasury.move
+++ b/treasury/sources/treasury.move
@@ -4,58 +4,29 @@
 /// A smart contract to manage the treasury and associated caps of a controlled coin.
 /// Features:
 /// - An admin can set permissions for different operations, and delete permissions, with effcient (immediate) revocation
-/// - A deny permission allow modifying the deny list for this coin.
-/// - A whitelist permission allows adding and removing addresses of market makets receivng minted and burning coins.
-/// - A mint permission allows minting coins to a whitelisted address, within some limit.
-/// - A burn permission allows burning coins from a whitelisted address.
-/// - The treasury contract never holds any coins, they are immediately transfered on mint or burn by others.
 /// - All addresses holding permissions can be multi-sigs.
-/// - Events are emitted to keep track of mint and burn events.
-///
-/// Still TODO features:
-/// - Allow cancelations of a partially authorized actions.
-/// - Allow coordination of a multi-sig action on chain.
 ///
 // Architecture notes:
 /// - The treasury contract is a public object that can be shared with others.
 /// - The treasury contract has a bag of capabilities that can be added and removed by the admin.
-/// - Whitelist entries are also represented as capabilities in the bag.
-/// - The treasury contract has a deny list that can be modified by the deny list capability.
-/// - When calling a function you indicate the name of the capability in the bag to authorize the action.
 module controlled_treasury::treasury {
     use std::type_name;
-    use sui::tx_context::{sender, epoch, TxContext};
-    use sui::coin::{Self, Coin, DenyCap, TreasuryCap};
-    use sui::deny_list::DenyList;
-    use sui::object::{Self, UID};
+    use sui::coin::{DenyCap, TreasuryCap};
     use sui::bag::{Bag, Self};
-    use sui::transfer;
-    use sui::event;
 
-    /// The Capability record does not exist.
-    const ENoAuthRecord: u64 = 0;
-    /// The limit for minting has been exceeded.
-    const EMintLimitExceeded: u64 = 1;
-    /// The capability record does not exist.
-    const ENoCapRecord: u64 = 2;
-    /// Trying to add a capability that already exists.
-    const ERecordExists: u64 = 3;
-    /// Trying to add an address that is already on denylist.
-    const EDenyEntryExists: u64 = 4;
-    /// Trying to remove an address that is not on denylist.
-    const ENoDenyEntry: u64 = 5;
-    /// Trying to add a whitelist entry that already exists.
-    const EWhitelistRecordExists: u64 = 6;
-    /// Trying to remove a whitelist entry that does not exist.
-    const ENoWhitelistRecord: u64 = 7;
     /// Trying to remove the last admin.
-    const EAdminsCantBeZero: u64 = 8;
+    const EAdminsCantBeZero: u64 = 0;
+    /// The Authorization record does not exist.
+    const ENoAuthRecord: u64 = 1;
+    /// The record already exists.
+    const ERecordExists: u64 = 2;
+    const ERemoveAuthFirst: u64 = 3;
 
     // A structure that wrapps the treasury cap of a coin and adds capabilities to so
     // that operations are controlled by a more granular and flexible policy. Can wrap
     // the capavilities after calling the constructor of a controlled coin.
     // Note: Upgrade cap can also be added to allow for upgrades
-    struct ControlledTreasury<phantom T> has key {
+    public struct ControlledTreasury<phantom T> has key {
         id: UID,
         /// Number of currently active admins.
         /// Can't ever be zero, as the treasury would be locked.
@@ -67,83 +38,41 @@ module controlled_treasury::treasury {
     }
 
     /// An administrator capability that may manage permissions
-    struct AdminCap has store, drop {}
-
-    /// A risk manager capability that managed KYC addresses
-    struct WhitelistCap has store, drop {}
-
-    /// A whitelist entry signifies that the address is authorized to burn, and safe to mint to
-    struct WhitelistEntry has store, drop {}
-
-    /// Define a capability to modify the deny list
-    struct DenylistCap has store, drop { }
-
-    /// Define a mint capability that may mint coins, with a limit
-    struct MintCap has store, drop {
-        limit: u64,
-        epoch: u64,
-        left: u64,
+    public struct AdminCap<phantom T> has key {
+        id: UID,
     }
-
-    // === Events ===
-
-    struct MintEvent<phantom T> has copy, drop {
-        amount: u64,
-        to: address,
-    }
-
-    struct BurnEvent<phantom T> has copy, drop {
-        amount: u64,
-        from: address,
-    }
+    
+    /// An authorization witness for the admin capability
+    public struct AdminAuth<phantom T> has store, drop {}
 
     // === DF Keys ===
 
     /// Namespace for dynamic fields: one for each of the Cap's.
-    struct RoleKey<phantom T> has copy, store, drop { owner: address }
+    public struct RoleKey<phantom W: store + drop> has copy, store, drop { id: ID }
 
     // Note all "address" can represent multi-signature addresses and be authorized at any threshold
 
     // === Capabilities ===
 
-    /// Create a new `AdminCap` to assign.
-    public fun new_admin_cap(): AdminCap { AdminCap {} }
-
-    /// Create a new `WhitelistCap` to assign.
-    public fun new_whitelist_cap(): WhitelistCap { WhitelistCap {} }
-
-    /// Create a new `MintCap` to assign.
-    public fun new_mint_cap(limit: u64, ctx: &TxContext): MintCap {
-        MintCap {
-            limit,
-            epoch: epoch(ctx),
-            left: limit,
-        }
-    }
-
-    /// Create a new `DenylistCap` to assign.
-    public fun new_denylist_cap(): DenylistCap { DenylistCap {} }
-
     /// Create a new controlled treasury by wrapping the treasury cap of a coin
-    /// The `ControlledTreasury` becomes a public shared object with an initial Admin capability assigned to
-    /// the provided owner.
+    /// The `ControlledTreasury` becomes a public shared object with an initial Admin capability is returned.
     ///
     /// The `ControlledTreasury` has to be `share`d after the creation.
     public fun new<T>(
         treasury_cap: TreasuryCap<T>,
         deny_cap: DenyCap<T>,
-        owner: address,
         ctx: &mut TxContext
-    ): ControlledTreasury<T> {
-        let treasury = ControlledTreasury {
+    ): (ControlledTreasury<T>, AdminCap<T>) {
+        let mut treasury = ControlledTreasury {
             id: object::new(ctx),
             treasury_cap,
             deny_cap,
             admin_count: 1,
             own_capabilities: bag::new(ctx),
         };
-        add_cap(&mut treasury, owner, AdminCap {});
-        treasury
+        let admin_cap = AdminCap { id: object::new(ctx) };
+        add_auth(&mut treasury, &admin_cap, AdminAuth<T> {});
+        (treasury, admin_cap)
     }
 
     #[lint_allow(share_owned)]
@@ -155,14 +84,14 @@ module controlled_treasury::treasury {
     /// Unpack the `ControlledTreasury` and return the treasury cap, deny cap
     /// and the Bag. The Bag must be cleared by the admin to be unpacked
     public fun deconstruct<T>(
-        treasury: ControlledTreasury<T>, ctx: &mut TxContext
+        admin_cap: &AdminCap<T>,
+        treasury: ControlledTreasury<T>,
     ): (TreasuryCap<T>, DenyCap<T>, Bag) {
-        assert!(has_cap<T, AdminCap>(&treasury, sender(ctx)), ENoAuthRecord);
-
+        assert!(has_auth<T, AdminAuth<T>>(&treasury, object::id(admin_cap)), ENoAuthRecord);
         // Deconstruct the structure and return the parts
         let ControlledTreasury {
             id,
-            admin_count,
+            admin_count: _,
             treasury_cap,
             deny_cap,
             own_capabilities
@@ -178,209 +107,95 @@ module controlled_treasury::treasury {
     /// Authorization checks that a capability under the given name is owned by the caller.
     ///
     /// Aborts if:
-    /// - the sender does not have AdminCap
+    /// - the sender does not have AdminAuth
     /// - the receiver already has a `C` cap
-    public fun add_capability<T, C: store + drop>(
+    public fun add_authorization<T, C: key, W: store + drop>(
+        admin_cap: &AdminCap<T>,
         treasury: &mut ControlledTreasury<T>,
-        for: address,
-        cap: C,
-        ctx: &mut TxContext
+        new_cap: &C,
+        auth_witness: W
     ) {
-        assert!(has_cap<T, AdminCap>(treasury, sender(ctx)), ENoAuthRecord);
-        assert!(!has_cap<T, C>(treasury, for), ERecordExists);
-
+        assert!(has_auth<T, AdminAuth<T>>(treasury, object::id(admin_cap)), ENoAuthRecord);
+        assert!(!has_auth<T, W>(treasury, object::id(new_cap)), ERecordExists);
         // using a reflection trick to update admin count when adding a new admin
-        if (type_name::get<C>() == type_name::get<AdminCap>()) {
+        if (type_name::get<W>() == type_name::get<AdminAuth<T>>()) {
             treasury.admin_count = treasury.admin_count + 1;
         };
 
-        add_cap(treasury, for, cap);
+        add_auth(treasury, new_cap, auth_witness);
     }
 
     /// Allow the admin to remove capabilities from the treasury
     /// Authorization checks that a capability under the given name is owned by the caller.
     ///
     /// Aborts if:
-    /// - the sender does not have `AdminCap`
+    /// - the sender does not have `AdminAuth`
     /// - the receiver does not have `C` cap
-    public fun remove_capability<T, C: store + drop>(
+    public fun remove_authorization<T, W: store + drop>(
+        admin_cap: &AdminCap<T>,
         treasury: &mut ControlledTreasury<T>,
-        for: address,
-        ctx: &mut TxContext
+        cap_id: ID
     ) {
-        assert!(has_cap<T, AdminCap>(treasury, sender(ctx)), ENoAuthRecord);
-        assert!(has_cap<T, C>(treasury, for), ENoCapRecord);
+        assert!(has_auth<T, AdminAuth<T>>(treasury, object::id(admin_cap)), ENoAuthRecord);
+        assert!(has_auth<T, W>(treasury, cap_id), ENoAuthRecord);
 
         // using a reflection trick to update admin count when removing an admin
         // make sure there's at least one admin always
-        if (type_name::get<C>() == type_name::get<AdminCap>()) {
+        if (type_name::get<W>() == type_name::get<AdminAuth<T>>()) {
             assert!(treasury.admin_count > 1, EAdminsCantBeZero);
             treasury.admin_count = treasury.admin_count - 1;
         };
 
-        let _: C = remove_cap(treasury, for);
+        remove_auth<T, W>(treasury, cap_id);
     }
 
-    // === Whitelist operations ===
-
-    /// Allow the owner of a whitelist capability to add a whitelist entry to the own_capabilities bag
-    /// Authorization checks that a capability under the given name is owned by the caller.
-    ///
-    /// Aborts if:
-    /// - the sender does not have a `WhitelistCap`
-    /// - the address is already whitelisted
-    public fun add_whitelist_entry<T>(
-        treasury: &mut ControlledTreasury<T>,
-        for: address,
-        ctx: &mut TxContext
+    public use fun delete_admin_cap as AdminCap.delete;
+    public fun delete_admin_cap<T>(
+        admin_cap: AdminCap<T>,
+        treasury: &ControlledTreasury<T>
     ) {
-        assert!(has_cap<T, WhitelistCap>(treasury, sender(ctx)), ENoAuthRecord);
-        assert!(!has_cap<T, WhitelistCap>(treasury, for), EWhitelistRecordExists);
-
-        add_cap(treasury, for, WhitelistEntry {});
-    }
-
-    /// Allow the owner of a whitelist capability to remove a whitelist entry from the own_capabilities bag
-    /// Authorization checks that a capability under the given name is owned by the caller.
-    ///
-    /// Aborts if:
-    /// - the sender does not have a WhitelistCap
-    /// - the address is not whitelisted
-    public fun remove_whitelist_entry<T>(
-        treasury: &mut ControlledTreasury<T>,
-        for: address,
-        ctx: &mut TxContext
-    ) {
-        assert!(has_cap<T, WhitelistCap>(treasury, sender(ctx)), ENoAuthRecord);
-        assert!(has_cap<T, WhitelistEntry>(treasury, for), ENoWhitelistRecord);
-
-        let _: WhitelistEntry = remove_cap(treasury, for);
-    }
-
-    // === Deny list operations ===
-
-    /// Adds an `entry` to the Denylist. Requires sender to have a `DenylistCap`
-    /// assigned to them.
-    ///
-    /// Aborts if:
-    /// - sender does not have this capability
-    /// - denylist already contains the record
-    public fun add_denylist_entry<T>(
-        treasury: &mut ControlledTreasury<T>,
-        deny_list: &mut DenyList,
-        entry: address,
-        ctx: &mut TxContext
-    ) {
-        assert!(has_cap<T, DenylistCap>(treasury, sender(ctx)), ENoAuthRecord);
-        assert!(!coin::deny_list_contains<T>(deny_list, entry), EDenyEntryExists);
-
-        coin::deny_list_add<T>(deny_list, &mut treasury.deny_cap, entry, ctx);
-    }
-
-    /// Removes an `entry` from the Denylist. Requires sender to have a `DenylistCap`
-    /// assigned to them.
-    ///
-    /// Aborts if:
-    /// - sender does not have this capability
-    /// - denylist does not contain this record
-    public fun remove_denylist_entry<T>(
-        treasury: &mut ControlledTreasury<T>,
-        deny_list: &mut DenyList,
-        entry: address,
-        ctx: &mut TxContext
-    ) {
-        assert!(has_cap<T, DenylistCap>(treasury, sender(ctx)), ENoAuthRecord);
-        assert!(coin::deny_list_contains<T>(deny_list, entry), ENoDenyEntry);
-
-        coin::deny_list_remove<T>(deny_list, &mut treasury.deny_cap, entry, ctx);
-    }
-
-    // Allow an authorized multi-sig to mint and transfer coins to a whitelisted address
-    ///
-    /// Aborts if:
-    /// - sender does not have MintCap assigned to them
-    /// - the amount is higher than the defined limit on MintCap
-    /// - the receiver is not Whitelisted
-    ///
-    /// Emits: MintEvent
-    public fun mint_and_transfer<T>(
-        treasury: &mut ControlledTreasury<T>,
-        amount: u64,
-        to: address,
-        ctx: &mut TxContext
-    ) {
-        assert!(has_cap<T, MintCap>(treasury, sender(ctx)), ENoAuthRecord);
-        assert!(has_cap<T, WhitelistEntry>(treasury, to), ENoWhitelistRecord);
-
-        // get the MintCap and check the limit; if a new epoch - reset it
-        let MintCap { limit, epoch, left } = get_cap_mut(treasury, sender(ctx));
-
-        // reset the limit if a new epoch
-        if (epoch(ctx) > *epoch) {
-            left = limit;
-            *epoch = epoch(ctx);
-        };
-
-        // Check that the amount is within the mint limit; update the limit
-        assert!(amount <= *left, EMintLimitExceeded);
-        *left = *left - amount;
-
-        // Emit the event and mint + transfer the coins
-        event::emit(MintEvent<T> { amount, to });
-        let new_coin = coin::mint(&mut treasury.treasury_cap, amount, ctx);
-        transfer::public_transfer(new_coin, to);
-    }
-
-    // Allow any external address on the whitelist to burn coins
-    // This assumes that any whitelisted addres has gone through KYC and banking info is available to send back USD
-    ///
-    /// Aborts if:
-    /// - sender is not on the whitelist
-    ///
-    /// Emits: BurnEvent
-    public fun burn<T>(
-        treasury: &mut ControlledTreasury<T>,
-        coin: Coin<T>,
-        ctx: &mut TxContext
-    ) {
-        assert!(has_cap<T, WhitelistEntry>(treasury, sender(ctx)), ENoAuthRecord);
-
-        event::emit(BurnEvent<T> {
-            amount: coin::value(&coin),
-            from: sender(ctx)
-        });
-
-        coin::burn(&mut treasury.treasury_cap, coin);
+        assert!(!has_auth<T, AdminAuth<T>>(treasury, object::id(&admin_cap)), ERemoveAuthFirst);
+        let AdminCap<T> { id } = admin_cap;
+        id.delete();
     }
 
     // === Utilities ===
 
     /// Check if a capability `Cap` is assigned to the `owner`. Publicly available for tests
     /// and interoperability with other packages / modules.
-    public fun has_cap<T, Cap: store>(treasury: &ControlledTreasury<T>, owner: address): bool {
-        bag::contains_with_type<RoleKey<Cap>, Cap>(&treasury.own_capabilities, RoleKey<Cap> { owner })
+    public fun has_auth<T, W: store + drop>(treasury: &ControlledTreasury<T>, id: ID): bool {
+        bag::contains_with_type<RoleKey<W>, W>(&treasury.own_capabilities, RoleKey<W> { id })
     }
 
     // === Private Utilities ===
 
-    #[allow(unused_function)]
-    /// Get a capability for the `owner`.
-    fun get_cap<T, Cap: store + drop>(treasury: &ControlledTreasury<T>, owner: address): &Cap {
-        bag::borrow(&treasury.own_capabilities, RoleKey<Cap> { owner })
-    }
-
-    /// Get a mutable ref to the capability for the `owner`.
-    fun get_cap_mut<T, Cap: store + drop>(treasury: &mut ControlledTreasury<T>, owner: address): &mut Cap {
-        bag::borrow_mut(&mut treasury.own_capabilities, RoleKey<Cap> { owner })
-    }
-
     /// Adds a capability `cap` for `owner`.
-    fun add_cap<T, Cap: store + drop>(treasury: &mut ControlledTreasury<T>, owner: address, cap: Cap) {
-        bag::add(&mut treasury.own_capabilities, RoleKey<Cap> { owner }, cap);
+    fun add_auth<T, C: key, W: store + drop>(treasury: &mut ControlledTreasury<T>, cap: &C, auth: W) {
+        bag::add(&mut treasury.own_capabilities, RoleKey<W> { id: object::id(cap) }, auth);
     }
 
     /// Remove a `Cap` from the `owner`.
-    fun remove_cap<T, Cap: store + drop>(treasury: &mut ControlledTreasury<T>, owner: address): Cap {
-        bag::remove(&mut treasury.own_capabilities, RoleKey<Cap> { owner })
+    fun remove_auth<T, W: store + drop>(treasury: &mut ControlledTreasury<T>, id: ID) {
+        bag::remove<RoleKey<W>, W>(&mut treasury.own_capabilities, RoleKey<W> { id });
+    }
+
+    public fun borrow_treasury_cap<T, C: key, W: store + drop>(self: &ControlledTreasury<T>, cap: &C, _: W): &TreasuryCap<T> {
+        assert!(has_auth<T, W>(self, object::id(cap)), ENoAuthRecord);
+        &self.treasury_cap
+    }
+
+    public fun borrow_treasury_cap_mut<T, C: key, W: store + drop>(self: &mut ControlledTreasury<T>, cap: &C, _: W): &mut TreasuryCap<T> {
+        assert!(has_auth<T, W>(self, object::id(cap)), ENoAuthRecord);
+        &mut self.treasury_cap
+    }
+
+    public fun borrow_deny_cap<T, C: key, W: store + drop>(self: &ControlledTreasury<T>, cap: &C, _: W): &DenyCap<T> {
+        assert!(has_auth<T, W>(self, object::id(cap)), ENoAuthRecord);
+        &self.deny_cap
+    }
+
+    public fun borrow_deny_cap_mut<T, C: key, W: store + drop>(self: &mut ControlledTreasury<T>, cap: &C, _: W): &mut DenyCap<T> {
+        assert!(has_auth<T, W>(self, object::id(cap)), ENoAuthRecord);
+        &mut self.deny_cap
     }
 }


### PR DESCRIPTION

Any package can have their own roles and Admin can add/remove roles.